### PR TITLE
Fix UI text no longer renders over everything:

### DIFF
--- a/Assets/Hai/LightboxViewer/Scripts/Editor/LightboxViewerEditorWindow.cs
+++ b/Assets/Hai/LightboxViewer/Scripts/Editor/LightboxViewerEditorWindow.cs
@@ -287,6 +287,11 @@ namespace Hai.LightboxViewer.Scripts.Editor
             ProjectRenderQueue.LoadLightbox(lightboxScene);
             _enabled = true;
             Realign();
+
+            // Fix UI text rendering over everything.
+            // This normally fixes itself when entering Play mode, but this will allow not needing to enter Play mode.
+            var LessEqual = 4;
+            Shader.SetGlobalInt("unity_GUIZTestMode", LessEqual);
         }
 
         private void Realign()


### PR DESCRIPTION
- Fix UI text no longer renders over everything without having to enter Play mode

Suggested by ScruffyRuffles